### PR TITLE
feat: try using swc to parse the CSS AST

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,7 @@ node_modules
 /.vscode/
 /dist/
 yarn.lock
+
+#Added by cargo
+/target
+Cargo.lock

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "swc-css-parser-glue"
+version = "0.0.1"
+description = "SWC CSS parser glue code"
+authors = ["yisibl"]
+edition = "2021"
+publish = false
+
+[lib]
+path = "crate/lib.rs"
+crate-type = ["cdylib", "rlib"]
+
+[dependencies]
+console_error_panic_hook = "0.1"
+serde = { version = "1.0", features = ["derive"] }
+swc_common = "0.27"
+swc_css_ast = "0.105.1"
+swc_css_parser = "0.114.0"
+wasm-bindgen = "0.2"
+serde-wasm-bindgen = "0.4"
+
+[profile.release]
+lto = true    # Enable Link Time Optimization
+opt-level = 3
+# Setting this to 1 may improve the performance of generated code, but may be slower to compile.
+# https://doc.rust-lang.org/rustc/codegen-options/index.html#codegen-units
+codegen-units = 1

--- a/crate/lib.rs
+++ b/crate/lib.rs
@@ -1,0 +1,65 @@
+use serde::Serialize;
+use swc_common::{BytePos, FileName, SourceFile, Span};
+use swc_css_ast::Stylesheet;
+use swc_css_parser::parser::ParserConfig;
+use wasm_bindgen::prelude::*;
+
+#[derive(Serialize)]
+struct ParserResult {
+    ast: Option<Stylesheet>,
+    errors: Vec<Error>,
+}
+
+#[derive(Serialize)]
+struct Error {
+    span: Span,
+    message: String,
+}
+
+// TODO: napi-rs binding
+#[wasm_bindgen]
+pub fn parse(code: String, allow_wrong_line_comments: bool) -> Result<JsValue, JsError> {
+    console_error_panic_hook::set_once();
+
+    let source_file = SourceFile::new(
+        FileName::Custom("input.css".into()),
+        false,
+        FileName::Custom("input.css".into()),
+        code,
+        BytePos(1),
+    );
+
+    let mut errors = vec![];
+    let result = match swc_css_parser::parse_file(
+        &source_file,
+        ParserConfig {
+            allow_wrong_line_comments,
+        },
+        &mut errors,
+    ) {
+        Ok(stylesheet) => ParserResult {
+            ast: Some(stylesheet),
+            errors: errors.into_iter().map(convert_recoverable_error).collect(),
+        },
+        Err(error) => {
+            let message = error.message().to_string();
+            ParserResult {
+                ast: None,
+                errors: vec![Error {
+                    span: error.into_inner().0,
+                    message,
+                }],
+            }
+        }
+    };
+
+    serde_wasm_bindgen::to_value(&result).map_err(JsError::from)
+}
+
+fn convert_recoverable_error(error: swc_css_parser::error::Error) -> Error {
+    let message = format!("{} (Recoverable)", error.message());
+    Error {
+        span: error.into_inner().0,
+        message,
+    }
+}

--- a/example/ast.json
+++ b/example/ast.json
@@ -1,0 +1,116 @@
+{
+  "ast": {
+    "type": "Stylesheet",
+    "span": {
+      "start": 1,
+      "end": 29,
+      "ctxt": 0
+    },
+    "rules": [
+      {
+        "type": "AtRule",
+        "span": {
+          "start": 1,
+          "end": 29,
+          "ctxt": 0
+        },
+        "name": {
+          "type": "Ident",
+          "span": {
+            "start": 2,
+            "end": 7,
+            "ctxt": 0
+          },
+          "value": "media",
+          "raw": "media"
+        },
+        "prelude": {
+          "type": "MediaQueryList",
+          "span": {
+            "start": 8,
+            "end": 25,
+            "ctxt": 0
+          },
+          "queries": [
+            {
+              "type": "MediaQuery",
+              "span": {
+                "start": 8,
+                "end": 25,
+                "ctxt": 0
+              },
+              "condition": {
+                "type": "MediaCondition",
+                "span": {
+                  "start": 8,
+                  "end": 25,
+                  "ctxt": 0
+                },
+                "conditions": [
+                  {
+                    "type": "MediaFeatureRange",
+                    "span": {
+                      "start": 8,
+                      "end": 25,
+                      "ctxt": 0
+                    },
+                    "left": {
+                      "type": "Ident",
+                      "span": {
+                        "start": 9,
+                        "end": 14,
+                        "ctxt": 0
+                      },
+                      "value": "width",
+                      "raw": "width"
+                    },
+                    "comparison": "<=",
+                    "right": {
+                      "type": "Length",
+                      "span": {
+                        "start": 18,
+                        "end": 24,
+                        "ctxt": 0
+                      },
+                      "value": {
+                        "type": "Number",
+                        "span": {
+                          "start": 18,
+                          "end": 22,
+                          "ctxt": 0
+                        },
+                        "value": 1200,
+                        "raw": "1200"
+                      },
+                      "unit": {
+                        "type": "Ident",
+                        "span": {
+                          "start": 22,
+                          "end": 24,
+                          "ctxt": 0
+                        },
+                        "value": "px",
+                        "raw": "px"
+                      }
+                    }
+                  }
+                ]
+              }
+            }
+          ]
+        },
+        "block": {
+          "type": "SimpleBlock",
+          "span": {
+            "start": 27,
+            "end": 29,
+            "ctxt": 0
+          },
+          "name": "{",
+          "value": []
+        }
+      }
+    ]
+  },
+  "errors": []
+}

--- a/example/wasm.js
+++ b/example/wasm.js
@@ -1,0 +1,19 @@
+const fs = require('fs').promises
+const { performance } = require('perf_hooks')
+
+const { parse } = require('../pkg/index')
+
+async function main() {
+  const css = `@media (width <= 1200px)  {}`
+
+  const t = performance.now()
+  const ast = parse(css)
+  console.info('✨ Done in', performance.now() - t, 'ms')
+
+  const astJson = JSON.stringify(ast, null, 2)
+  console.info('input CSS: \n' + css + '\n', astJson)
+
+  fs.writeFile(__dirname + '/ast.json', astJson)
+}
+
+main()

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "format:md": "prettier --parser markdown --write './**/*.md'",
     "format:json": "prettier --parser json --write './**/*.json'",
     "lint": "eslint . -c ./.eslintrc.yml './src/**/*.{ts,tsx,js}'",
-    "lint:fix": "eslint . -c ./.eslintrc.yml './src/**/*.{ts,tsx,js}' --fix"
+    "lint:fix": "eslint . -c ./.eslintrc.yml './src/**/*.{ts,tsx,js}' --fix",
+    "build:wasm": "wasm-pack build --target nodejs --out-name index --release"
   },
   "repository": "postcss/postcss-at-rule-parser",
   "keywords": [


### PR DESCRIPTION
`swc` has a well-developed CSS at Rule parsing, and @alexander-akait, the main CSS lead in swc, is passionate about open source and his contributions to the CSS community are evident to all. I trust him.

The Rust community is also full of energy, and I believe that half of the future CSS tools will be a combination of JS + Rust.

It's worth a try.

As for the performance, wait for the next test after adding the `napi-rs` binding.

## Build

```bash
npm run build:wasm
node example/wasm
```
